### PR TITLE
Avoid waiting in exec_background(), closes #6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
+
 1.2:
   - Windows: show informative system error messages on failures
+  - Unix: exec_background() does not wait for 1/2 a second
+    (#6, #7, @gaborcsardi)
 
 1.1:
   - Switch from SIGHUP to SIGKILL to kill child process


### PR DESCRIPTION
Instead, we have a pipe that is set to FD_CLOEXEC in the child,
so if there is nothing to read in the parent, then we know that
the exec was successful. If it was not, then we write the error
code in the pipe, so the parent can read it out.

All tests pass without modification. 