### PR TITLE
First SIGCHLD handler (#5)

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,35 @@
+
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+
+#include <signal.h>
+#include <sys/wait.h>
+
+void sys_sigchld_callback(int sig, siginfo_t *info, void *ctx) {
+  if (sig != SIGCHLD) return;
+  pid_t pid = info->si_pid;
+  int wstat;
+  waitpid(pid, &wstat, WNOHANG);
+}
+
+/* TODO: use oldact as well... */
+static void setup_signal_handler() {
+  struct sigaction action;
+  action.sa_sigaction = sys_sigchld_callback;
+  action.sa_flags = SA_SIGINFO | SA_RESTART;
+  sigaction(SIGCHLD, &action, /* oldact= */ NULL);
+}
+
+static void remove_signal_handler() {
+  struct sigaction action;
+  action.sa_handler = SIG_DFL;
+  sigaction(SIGCHLD, &action, /* oldact= */ NULL);
+}
+
+void R_init_sys(DllInfo *dll) {
+  setup_signal_handler();
+}
+
+void R_unload_sys(DllInfo *dll) {
+  remove_signal_handler();
+}


### PR DESCRIPTION
Minimalistic, but it already gets rid of the zombie processes.

Currently it interferes with `parallel`'s fork clusters, because neither packages keep the other's signal handler. We would need to work out some cooperative solution, which would need to go in base R, to avoid this. E.g. storing a list of handlers for the various signals and add API to R to install/uninstall them.

You can merge this if you want, and then we can discuss improvements, especially about storing the exit status, so that one can query it from R.