### PR TITLE
Copy escape function from processx

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sys
 Type: Package
 Title: Portable System Utilities
-Version: 1.5
+Version: 1.5.9000
 Authors@R: c(
     person("Jeroen", "Ooms", , "jeroen@berkeley.edu", role = c("aut", "cre")),
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = "ctb"))

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 PKG_SAFE = $(_R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_)
 PKG_CPPFLAGS = -DSYS_BUILD_SAFE$(PKG_SAFE)
-OBJECTS = win32/exec.o util.o
+OBJECTS = win32/exec.o win32/escape.o util.o
 
 all: clean
 

--- a/src/win32/escape.c
+++ b/src/win32/escape.c
@@ -1,0 +1,155 @@
+#include <Rinternals.h>
+#include <windows.h>
+
+/* copied from processx */
+static WCHAR* processx__quote_cmd_arg(const WCHAR *source, WCHAR *target) {
+  size_t len = wcslen(source);
+  size_t i;
+  int quote_hit;
+  WCHAR* start;
+
+  if (len == 0) {
+    /* Need double quotation for empty argument */
+    *(target++) = L'"';
+    *(target++) = L'"';
+    return target;
+  }
+
+  if (NULL == wcspbrk(source, L" \t\"")) {
+    /* No quotation needed */
+    wcsncpy(target, source, len);
+    target += len;
+    return target;
+  }
+
+  if (NULL == wcspbrk(source, L"\"\\")) {
+    /*
+     * No embedded double quotes or backlashes, so I can just wrap
+     * quote marks around the whole thing.
+     */
+    *(target++) = L'"';
+    wcsncpy(target, source, len);
+    target += len;
+    *(target++) = L'"';
+    return target;
+  }
+
+  /*
+   * Expected input/output:
+   *   input : hello"world
+   *   output: "hello\"world"
+   *   input : hello""world
+   *   output: "hello\"\"world"
+   *   input : hello\world
+   *   output: hello\world
+   *   input : hello\\world
+   *   output: hello\\world
+   *   input : hello\"world
+   *   output: "hello\\\"world"
+   *   input : hello\\"world
+   *   output: "hello\\\\\"world"
+   *   input : hello world\
+   *   output: "hello world\\"
+   */
+
+  *(target++) = L'"';
+  start = target;
+  quote_hit = 1;
+
+  for (i = len; i > 0; --i) {
+    *(target++) = source[i - 1];
+
+    if (quote_hit && source[i - 1] == L'\\') {
+      *(target++) = L'\\';
+    } else if(source[i - 1] == L'"') {
+      quote_hit = 1;
+      *(target++) = L'\\';
+    } else {
+      quote_hit = 0;
+    }
+  }
+  target[0] = L'\0';
+  wcsrev(start);
+  *(target++) = L'"';
+  return target;
+}
+
+int processx__make_program_args(SEXP args, int verbatim_arguments,
+                                       WCHAR **dst_ptr) {
+  const char* arg;
+  WCHAR* dst = NULL;
+  WCHAR* temp_buffer = NULL;
+  size_t dst_len = 0;
+  size_t temp_buffer_len = 0;
+  WCHAR* pos;
+  int arg_count = LENGTH(args);
+  int err = 0;
+  int i;
+
+  /* Count the required size. */
+  for (i = 0; i < arg_count; i++) {
+    DWORD arg_len;
+    arg = CHAR(STRING_ELT(args, i));
+
+    arg_len = MultiByteToWideChar(
+      /* CodePage =       */ CP_UTF8,
+      /* dwFlags =        */ 0,
+      /* lpMultiByteStr = */ arg,
+      /* cbMultiBytes =   */ -1,
+      /* lpWideCharStr =  */ NULL,
+      /* cchWideChar =    */ 0);
+
+      if (arg_len == 0) { return GetLastError(); }
+
+      dst_len += arg_len;
+
+      if (arg_len > temp_buffer_len) { temp_buffer_len = arg_len; }
+  }
+
+  /* Adjust for potential quotes. Also assume the worst-case scenario */
+  /* that every character needs escaping, so we need twice as much space. */
+  dst_len = dst_len * 2 + arg_count * 2;
+
+  /* Allocate buffer for the final command line. */
+  dst = (WCHAR*) R_alloc(dst_len, sizeof(WCHAR));
+
+  /* Allocate temporary working buffer. */
+  temp_buffer = (WCHAR*) R_alloc(temp_buffer_len, sizeof(WCHAR));
+
+  pos = dst;
+  for (i = 0; i < arg_count; i++) {
+    DWORD arg_len;
+    arg = CHAR(STRING_ELT(args, i));
+
+    /* Convert argument to wide char. */
+    arg_len = MultiByteToWideChar(
+      /* CodePage =       */ CP_UTF8,
+      /* dwFlags =        */ 0,
+      /* lpMultiByteStr = */ arg,
+      /* cbMultiBytes =   */ -1,
+      /* lpWideCharStr =  */ temp_buffer,
+      /* cchWideChar =    */ (int) (dst + dst_len - pos));
+
+      if (arg_len == 0) {
+        err = GetLastError();
+        goto error;
+      }
+
+      if (verbatim_arguments) {
+        /* Copy verbatim. */
+        wcscpy(pos, temp_buffer);
+        pos += arg_len - 1;
+      } else {
+        /* Quote/escape, if needed. */
+        pos = processx__quote_cmd_arg(temp_buffer, pos);
+      }
+
+      *pos++ = i < arg_count - 1 ? L' ' : L'\0';
+  }
+
+  *dst_ptr = dst;
+  return 0;
+
+  error:
+    return err;
+}


### PR DESCRIPTION
Copy over escape functions from processx. This seems to break unit tests. Need to investigate. I think processx uses `shQuote()` before passing the args to the C function?